### PR TITLE
Fix rays outside the box

### DIFF
--- a/src/View.elm
+++ b/src/View.elm
@@ -37,8 +37,16 @@ element walls ( width, height ) ( x, y ) =
                 solveRays walls rayPosition
                   |> List.sortBy (.vector >> .angle)
 
-              cycled =
-                solutions ++ (List.take 1 solutions)
+              first = List.head solutions
+              last = List.head <| List.reverse solutions
+              cycled = case (first, last) of
+                (Just first, Just last) ->
+                  if abs (first.vector.angle - last.vector.angle) > degrees 180 then
+                    solutions ++ (List.take 1 solutions)
+                  else
+                    solutions
+                _ ->
+                  solutions
              in
               List.map2 (,) cycled (List.tail cycled |> Maybe.withDefault [])
                 |> List.map (drawTriangles rayColor)


### PR DESCRIPTION
I know you declared behaviour outside the box to be undefined (https://twitter.com/krisajenkins/status/726090881611227136) but that just sounded like a challenge :grinning: 

The issue in the old code was that the triangle added to complete the circle doesn't make sense outside the square (logically, it's the ray that goes out to infinity off the side of the screen), this change only adds that triangle if the angle at the mouse pointer is under half a circle.  This means that, so long as the bounding box in convex, the extra triangle won't ever get added outside the box (concave bounding boxes won't work when the pointer is in one of the "caves").

Not the most elegant fix to my mind, but I'm pretty new to elm, and the result is what I was going for, please suggest a more elegant fix if you think of one.
