### PR TITLE
render walls alone if the user has not yet moved the mouse

### DIFF
--- a/src/View.elm
+++ b/src/View.elm
@@ -9,12 +9,7 @@ import View.Svg
 root : Model -> Html msg
 root model =
     div []
-        [ case model.mouse of
-            Just position ->
-                View.Svg.root model.walls position
-
-            _ ->
-                Html.text "Initializing."
+        [ View.Svg.root model.walls model.mouse
         , copy
         ]
 

--- a/src/View/Svg.elm
+++ b/src/View/Svg.elm
@@ -10,16 +10,26 @@ import Types exposing (..)
 import Vectors exposing (..)
 
 
-root : Walls -> Mouse.Position -> Html msg
-root walls position =
-    svg
-        [ width "600"
-        , height "600"
-        ]
-        [ drawRays walls position
-        , drawWalls walls
-        , drawCursor position
-        ]
+root : Walls -> Maybe Mouse.Position -> Html msg
+root walls pos =
+    case pos of
+        Just position ->
+            svg
+                [ width "600"
+                , height "600"
+                ]
+                [ drawRays walls position
+                , drawWalls walls
+                , drawCursor position
+                ]
+
+        _ ->
+            svg
+                [ width "600"
+                , height "600"
+                ]
+                [ drawWalls walls
+                ]
 
 
 neighbours : List a -> List ( a, a )


### PR DESCRIPTION
Currently, if you go to the page and you're not moving the mouse, it gives an "Initializing" message. It makes more sense to render the walls on their own. Svg could be dried up but it's not too complicated, I'm hoping.